### PR TITLE
Add downloadOptions and interlex references

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -53,12 +53,14 @@
     },
     {
       "information": {
-        "value": "pain"
+        "value": "pain",
+		"valueIRI": "http://uri.interlex.org/ilx_0108364"
       }
     },
     {
       "information": {
-        "value": "balance"
+        "value": "balance",
+		"valueIRI": "http://uri.interlex.org/ilx_0101080"
       }
     },
     {
@@ -68,7 +70,8 @@
     },
     {
       "information": {
-        "value": "sleep"
+        "value": "sleep",
+		"valueIRI": "http://uri.interlex.org/ilx_0381893"
       }
     },
     {
@@ -88,22 +91,26 @@
     },
     {
       "information": {
-        "value": "treatment"
+        "value": "treatment",
+		"valueIRI": "http://uri.interlex.org/ilx_0111925"
       }
     },
     {
       "information": {
-        "value": "neuroimaging"
+        "value": "neuroimaging",
+		"valueIRI": "http://uri.interlex.org/ilx_0741206"
       }
     },
     {
       "information": {
-        "value": "MRI"
+        "value": "MRI",
+		"valueIRI": "http://uri.interlex.org/ilx_0779748"
       }
     },
     {
       "information": {
-        "value": "locomotion"
+        "value": "locomotion",
+		"valueIRI": "http://uri.interlex.org/ilx_0106332"
       }
     },
     {

--- a/DATS.json
+++ b/DATS.json
@@ -317,6 +317,14 @@
         }
       ]
     },
+	{
+		"category": "downloadOptions",
+		"values": [
+			{
+				"value": "offsite"
+			}
+		]
+	},
     {
       "category": "REB_statement",
       "values": [


### PR DESCRIPTION
This PR updates `DATS.json` with a downloadOptions entry containing the dummy value "offsite", and also adds interlex annotations to keywords.